### PR TITLE
Chat ReadChk 구현 및 View 수정

### DIFF
--- a/src/main/java/com/community/TestDataInit.java
+++ b/src/main/java/com/community/TestDataInit.java
@@ -52,7 +52,7 @@ public class TestDataInit {
         if (!accountRepository.existsByStudentId("17-100000")) {
             accountRepository.save(new Account(null, "tester@nsu.ac.kr", "tester", "17-100000", "테스터", passwordEncoder.encode("test1234!"),
                     true, "asdf", null, null, LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1),
-                    null, null, null,null, null, null,null, null, true, true, false,
+                    null, null, null,null, null, null,null,null, null, true, true, false,
                     true, true, true, null, 0));
             /*boardRepository.save(new Board(null, "자유", "", "수강신청 다들 성공기원🙏", null,null,  null, false,0,BOARD_CONTENT_VALUE, accountRepository.findByEmail("test@naver.com"), 0, LocalDateTime.now().minusMinutes(20), null));
             boardRepository.save(new Board(null, "질문", "college", "수강신청은 어떻게 하나요?",null, null, null, false,0,"ㅈㄱㄴ", accountRepository.findByEmail("test@naver.com"), 0, LocalDateTime.now().minusSeconds(40), null));
@@ -62,7 +62,7 @@ public class TestDataInit {
         if (!accountRepository.existsByStudentId("17-100424")) {
             accountRepository.save(new Account(null, "dlwlgns1240@nsu.ac.kr", "ezhoon", "17-100424", "이지훈", passwordEncoder.encode("12401240"),
                     true, "asdf1", null, null, LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1),
-                    "잘 부탁드립니다", "https://github.com/lee-ji-hoon", "대학생", "서울, 용산", null, null, null,null, true, true,
+                    "잘 부탁드립니다", "https://github.com/lee-ji-hoon", "대학생", "서울, 용산", null, null, null,null,null, true, true,
                     true, true, true, true, null, 0));
             /*boardRepository.save(new Board(null, "자유", "", "오늘 학식은 뭔가요?", null, null, null, false, 0,BOARD_CONTENT_VALUE, accountRepository.findByEmail("dlwlgns1240@naver.com"), 0, LocalDateTime.now().minusHours(1), null));*/
         }
@@ -78,7 +78,7 @@ public class TestDataInit {
         if (!accountRepository.existsByStudentId("17-100444")) {
             accountRepository.save(new Account(null, "kawnsdud@nsu.ac.kr", "jwhy", "17-100444", "준영", passwordEncoder.encode("test1234!"),
                     true, "asdf12", null, null, LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1),
-                    "hello", "https://github.com/Jwhyee", "대학생", "경기도, 수원", null, null, null, null, true, true,
+                    "hello", "https://github.com/Jwhyee", "대학생", "경기도, 수원", null, null, null,null, null, true, true,
                     true, true, true, true, null, 0));
             /*boardRepository.save(new Board(null, "자유", "", "밥 먹으러 갈사람 9함",null, null, null, false, 0,FORUM_TEST_CONTENT_VALUE3, accountRepository.findByEmail("tester0@naver.com"), 0, LocalDateTime.now().minusHours(1), null));*/
         }
@@ -86,7 +86,7 @@ public class TestDataInit {
         if (!accountRepository.existsByStudentId("11-111111")) {
             accountRepository.save(new Account(null, "croce@nsu.ac.kr", "CROCE", "11-111111", "학생회", passwordEncoder.encode("mmult1234!"),
                     true, "asdf123", null, null, LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1),
-                    "안녕하세요 27대 학생회 CROCE 입니다.", "", "대학생", "충청북도, 성환", null, null, null, null, true, true,
+                    "안녕하세요 27대 학생회 CROCE 입니다.", "", "대학생", "충청북도, 성환", null, null, null,null, null, true, true,
                     true, true, true, true, null, 0));
             /*councilRepository.save(new Council(null, "행사", "💛친해지길 바라💛", "전체 학년", "http://naver.me/G3K7QAeA", "010-1234-1234", COUNCIL_CONTENT_VALUE, accountRepository.findByEmail("croce@naver.com"), 0, LocalDate.of(2022, 3, 23), LocalDate.of(2022, 3, 23), LocalDate.of(2022, 3, 7), LocalDate.of(2022, 3, 14), LocalDateTime.now()));
             councilRepository.save(new Council(null, "행사", "🍦기말 간식행사🍦", "전체 학년", null, "010-1234-1234", COUNCIL_CONTENT_VALUE1, accountRepository.findByEmail("croce@naver.com"), 0, LocalDate.of(2021, 12, 5), LocalDate.of(2021, 12, 5), LocalDate.of(2021, 11, 29), LocalDate.of(2021, 12, 02), LocalDateTime.now()));

--- a/src/main/java/com/community/domain/account/Account.java
+++ b/src/main/java/com/community/domain/account/Account.java
@@ -1,6 +1,7 @@
 package com.community.domain.account;
 
 import com.community.domain.alarm.Alarm;
+import com.community.domain.chat.Chat;
 import com.community.service.BoardService;
 import com.community.domain.likes.Likes;
 import com.community.domain.market.Market;
@@ -81,6 +82,9 @@ public class Account {
 
     @OneToMany(mappedBy = "toAccount", fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Alarm> alarmList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "sender", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Chat> chatList = new ArrayList<>();
 
     @OneToMany(mappedBy = "seller", cascade = CascadeType.ALL)
     private List<Market> marketsList = new ArrayList<>();

--- a/src/main/java/com/community/service/ChatService.java
+++ b/src/main/java/com/community/service/ChatService.java
@@ -15,7 +15,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -87,6 +90,30 @@ public class ChatService {
                 chatRepository.save(chat);
             }
         }
+    }
+
+    public Map<Long, String> dateCheckFunction(List<Room> myRooms) {
+        Map<Long, String> dateMap = new HashMap<>();
+        Map<String, Long> newMap = new HashMap<>();
+        for (Room myRoom : myRooms) {
+            log.info("roomId 조회 : " + myRoom.getRoomId());
+            List<Chat> chatList = myRoom.getChatList();
+            for (Chat findChatList : chatList) {
+                LocalDateTime chatDate = findChatList.getSendTime();
+                String convertChatDate = chatDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                newMap.put(convertChatDate, myRoom.getRoomId());
+            }
+            for (String s : newMap.keySet()) {
+                dateMap.put(myRoom.getRoomId(), s);
+            }
+        }
+        for (Long key : dateMap.keySet()) {
+            log.info("key 조회 : " + key);
+        }
+        for (String value : dateMap.values()) {
+            log.info("value 조회 : " + value);
+        }
+        return dateMap;
     }
 
 }

--- a/src/main/java/com/community/service/ChatService.java
+++ b/src/main/java/com/community/service/ChatService.java
@@ -80,4 +80,13 @@ public class ChatService {
         roomRepository.save(currentRoom);
     }
 
+    public void readCheckService(List<Chat> findChatLists, Account account) {
+        for (Chat chat : findChatLists) {
+            if (chat.getSender() != account) {
+                chat.setReadChk(true);
+                chatRepository.save(chat);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/community/web/controller/ChatController.java
+++ b/src/main/java/com/community/web/controller/ChatController.java
@@ -34,6 +34,7 @@ public class ChatController {
 
     private final AccountRepository accountRepository;
     private final RoomRepository roomRepository;
+    private final ChatRepository chatRepository;
     private final ChatService chatService;
 
     @GetMapping("/chat/lists")
@@ -51,6 +52,18 @@ public class ChatController {
         model.addAttribute("myRooms", myRooms);
         model.addAttribute(account);
         return "chat/chat-detail";
+    }
+
+    // 읽음 확인
+    @ResponseBody
+    @RequestMapping(value = "/chat/readChk")
+    public String readCheck(@RequestParam(value = "roomId") Long roomId,
+                            @CurrentUser Account account) {
+        Room currentRoom = roomRepository.findByRoomId(roomId);
+        List<Chat> findChatLists = chatRepository.findByRoom(currentRoom);
+        chatService.readCheckService(findChatLists, account);
+
+        return "";
     }
 
     // 채팅방에서 쪽지 보내기

--- a/src/main/java/com/community/web/controller/ChatController.java
+++ b/src/main/java/com/community/web/controller/ChatController.java
@@ -45,9 +45,7 @@ public class ChatController {
         List<Room> myRooms = new ArrayList<>();
         myRooms.addAll(findRoomHostList);
         myRooms.addAll(findRoomAttenderList);
-        for (Room myRoom : myRooms) {
-            log.info("myRoom={}", myRoom);
-        }
+        chatService.dateCheckFunction(myRooms);
 
         model.addAttribute("myRooms", myRooms);
         model.addAttribute(account);

--- a/src/main/resources/static/assets/css/style.css
+++ b/src/main/resources/static/assets/css/style.css
@@ -10189,8 +10189,8 @@ input[type="button"].dark1, input[type="submit"].dark1 {
 .user_status {
   position: absolute;
   content: "";
-  height: 14px;
-  width: 14px;
+  height: 16px;
+  width: 16px;
   background-color: #c0c0c0;
   bottom: 0;
   right: 0;
@@ -10201,7 +10201,7 @@ input[type="button"].dark1, input[type="submit"].dark1 {
 }
 
 .user_status.status_online {
-  background-color: #38b653;
+  background-color: #3b82f6;
   visibility: visible;
 }
 

--- a/src/main/resources/templates/chat/chat-detail.html
+++ b/src/main/resources/templates/chat/chat-detail.html
@@ -83,9 +83,13 @@
                                 <th:block th:if="${account == chatRoom.roomHost}">
                                     <h4 th:text="${chatRoom.roomAttender.nickname}">상대방 닉네임</h4>
                                 </th:block>
-                                <a href="#" class="message-action text-blue-500 flex-none" th:uk-toggle="|target: #roomNum${chatRoom.roomId};|">
-                                    <ion-icon name="arrow-back-outline" class="w-6 h-6"></ion-icon>
-                                </a>
+                                <form th:id="|readChkForm${chatRoom.roomId}|" onsubmit="return false">
+                                    <input class="hidden" th:value="${chatRoom.roomId}" name="roomId"/>
+                                    <a href="#" class="message-action text-blue-500 flex-none" th:id="|readChkBtn${chatRoom.roomId}|" th:uk-toggle="|target: #roomNum${chatRoom.roomId};|">
+                                        <ion-icon name="arrow-back-outline" class="w-6 h-6"></ion-icon>
+                                    </a>
+                                </form>
+
                             </div>
 
                             <div class="message-content-scrolbar" th:id="|chatScroll${chatRoom.roomId}|" data-simplebar>
@@ -178,12 +182,22 @@
             $(`#roomNum${roomId}`)
                 .attr('hidden', 'false')
                 .css('display', 'block');
-            delay(function (){
+            delay(function () {
                 console.log($(`#chatContents${roomId}`)[0].scrollHeight);
                 $('.simplebar-content').stop().animate({
                     scrollTop: $(`#chatContents${roomId}`)[0].scrollHeight
                 }, 0);
             }, 1);
+            $.ajax({
+                url:'/chat/readChk',
+                type:'get',
+                contentType: "application/x-www-form-urlencoded; charset=utf-8",
+                data : $(`#readChkForm${roomId}`).serialize(),
+                success : function (){
+                    $('.messages-inbox').load(location.href+' .messages-inbox');
+                    console.log(roomId + "확인");
+                }
+            });
             exRoomNum = roomId;
             return exRoomNum;
         }

--- a/src/main/resources/templates/chat/chat-detail.html
+++ b/src/main/resources/templates/chat/chat-detail.html
@@ -161,6 +161,14 @@
         </div>
     </div>
 <script type="application/javascript">
+    // Delay 함수
+    const delay = (function (){
+        var timer = 0;
+        return function (callback, ms) {
+            clearTimeout(timer);
+            timer = setTimeout(callback, ms);
+        };
+    })();
     var exRoomNum;
     let roomBtn = {
         roomBtnFx: function (roomId) {
@@ -170,20 +178,18 @@
             $(`#roomNum${roomId}`)
                 .attr('hidden', 'false')
                 .css('display', 'block');
+            delay(function (){
+                console.log($(`#chatContents${roomId}`)[0].scrollHeight);
+                $('.simplebar-content').stop().animate({
+                    scrollTop: $(`#chatContents${roomId}`)[0].scrollHeight
+                }, 0);
+            }, 1);
             exRoomNum = roomId;
             return exRoomNum;
         }
     }
     let chatSendFx = {
         chatSendAjax: function (roomId) {
-            // Delay 함수
-            const delay = (function (){
-                var timer = 0;
-                return function (callback, ms) {
-                    clearTimeout(timer);
-                    timer = setTimeout(callback, ms);
-                };
-            })();
             $.ajax({
                 url:'/chat/send',
                 type:'get',
@@ -194,26 +200,14 @@
                         .load(location.href+` #chatContents${roomId}`);
                     $('.messages-inbox').load(location.href+' .messages-inbox');
                     $(`#chatInput${roomId}`)
-                        .val('')
-                        .attr("readonly", true)
-                        .attr("placeholder", "5초 뒤에 쪽지를 입력할 수 있습니다.");
-                    $(`#chatSendBtn${roomId}`)
-                        .attr('hidden', 'true');
+                        .val('');
+                    $('.simplebar-content').stop().animate({
+                        scrollTop: $(`#chatContents${roomId}`)[0].scrollHeight
+                    }, 2500);
                 }
             });
-            $('.simplebar-content').stop().animate({
-                scrollTop: $('.simplebar-content')[0].scrollHeight + $('.content-wrapper').outerHeight(true) + 9999999
-            }, 100);
-            /*$(`#chatScroll${roomId}`).stop().animate({
-                scrollTop: $(`#chatScroll${roomId}`)[0].scrollHeight + $(`#chatScroll${roomId}`).outerHeight(true) + 5000
-            }, 100);*/
-            delay(function (){
-                $(`#chatInput${roomId}`)
-                    .removeAttr("readonly")
-                    .attr("placeholder","내용을 입력해주세요.");
-                $(`#chatSendBtn${roomId}`)
-                    .removeAttr("hidden")
-            }, 5000);
+
+
         }
     }
     document.addEventListener('keydown', function(event) {

--- a/src/main/resources/templates/chat/chat-detail.html
+++ b/src/main/resources/templates/chat/chat-detail.html
@@ -35,6 +35,7 @@
                         <div class="messages-inbox-inner" data-simplebar>
                             <ul class="chat-room-lists">
                                 <li th:each="room : ${myRooms}">
+                                    <p th:text="${room.chatList.size()}"></p>
                                     <a href="#" th:uk-toggle="|target: #roomNum${room.roomId};|"
                                        th:onclick="|roomBtn.roomBtnFx(${room.roomId})|">
                                         <div class="message-avatar">
@@ -46,6 +47,11 @@
                                                 <img th:if="${!#strings.isEmpty(room.roomHost?.profileImage)}"
                                                      th:src="${room.roomHost?.profileImage}"
                                                      alt=""/>
+                                                <th:block th:if="${!room.chatList.get(room.chatList.size()-1).readChk}">
+                                                    <th:block th:if="${room.chatList.get(room.chatList.size()-1).sender != account}">
+                                                        <span class="user_status status_online"></span>
+                                                    </th:block>
+                                                </th:block>
                                             </th:block>
                                             <th:block th:if="${account == room.roomHost}">
                                                 <svg th:if="${#strings.isEmpty(room.roomAttender?.profileImage)}"
@@ -54,6 +60,11 @@
                                                 <img th:if="${!#strings.isEmpty(room.roomAttender?.profileImage)}"
                                                      th:src="${room.roomAttender?.profileImage}"
                                                      alt=""/>
+                                                <th:block th:if="${!room.chatList.get(room.chatList.size()-1).readChk}">
+                                                    <th:block th:if="${room.chatList.get(room.chatList.size()-1).sender != account}">
+                                                        <span class="user_status status_online"></span>
+                                                    </th:block>
+                                                </th:block>
                                             </th:block>
                                         </div>
                                         <div class="message-by">

--- a/src/main/resources/templates/chat/chat-detail.html
+++ b/src/main/resources/templates/chat/chat-detail.html
@@ -35,7 +35,6 @@
                         <div class="messages-inbox-inner" data-simplebar>
                             <ul class="chat-room-lists">
                                 <li th:each="room : ${myRooms}">
-                                    <p th:text="${room.chatList.size()}"></p>
                                     <a href="#" th:uk-toggle="|target: #roomNum${room.roomId};|"
                                        th:onclick="|roomBtn.roomBtnFx(${room.roomId})|">
                                         <div class="message-avatar">

--- a/src/main/resources/templates/theme-fragments.html
+++ b/src/main/resources/templates/theme-fragments.html
@@ -5,6 +5,15 @@
 
 <head th:fragment="head">
     <style>
+        #loadingSpin {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            z-index: 100;
+            width: 3rem;
+            height: 3rem;
+        }
+
         .custom-file label {
             color: white;
             cursor: pointer;
@@ -183,11 +192,11 @@
     <script src="https://unpkg.com/ionicons@5.2.3/dist/ionicons.js"></script>
 
     <script>
-
         window.jdenticon_config = {
             replaceMode: "observe"
         };
         $(document).ready(function () {
+            $('#loadingSpin').hide();
             function addObserverIfDesiredNodeAvailable() {
                 var composeBox = document.querySelectorAll(".no")[2];
                 if (!composeBox) {
@@ -266,6 +275,9 @@
 
 <!-- Header -->
 <header th:fragment="header">
+    <div id="loadingSpin">
+        <div style="border-top-color:transparent" class="w-16 h-16 border-4 border-blue-400 border-solid rounded-full animate-spin"></div>
+    </div>
     <div class="bg-white py-4 shadow dark:bg-gray-800" sec:authorize="!isAuthenticated()">
         <style>
             input , .bootstrap-select.btn-group button {
@@ -526,7 +538,6 @@
 
 <!-- sidebar -->
 <div th:fragment="side_bar" class="sidebar">
-
     <div class="sidebar_inner">
         <ul>
             <li th:classappend="${currentSideMenu == 'study'}? active"><a th:href="@{/study}">

--- a/src/main/resources/templates/theme-fragments.html
+++ b/src/main/resources/templates/theme-fragments.html
@@ -453,7 +453,7 @@
                                 </li>
                             </ul>
                         </div>
-                        <a class="see-all"> 전체 보기</a>
+                        <a class="see-all" th:href="@{/chat/lists}"> 전체 보기</a>
                     </div>
 
 


### PR DESCRIPTION
- [ ]  쪽지 보내면 메세지가 위로 올라가는 애니메이션 추가(스크롤이 올라가는 거임 사실 ㅋ)
- [ ] Account에 chatList 추가
`create-drop 필수는 아님`
나중에 너 alramList 구현한거 설명 한 번만 해주라
- [ ] 로딩바 구현 -> theme-fragments에 header에 넣어둠 근데 얘 위치가 위쪽이라 로딩바도 위쪽으로 치우침..
채팅 많이 보내놓고 가면 로딩 길어지는거 볼 수 있음
- [ ] readChk 로직 추가 및 구현 완료 -> room 클릭하면 ajax로 readChk진행
- [ ] 채팅방 읽지 않음 표시 추가 -> 채팅방 사이드에 계정 이미지 우측하단에 파란색

### 아직 수정 안 함
- 모바일 길이 조정

### **알람 건의사항**
- 파란 글씨로 나오는 부분 혹시 그 댓글에 대한 내용을 띄울 수 있을까??
- 좋아요는 그대로 있어도 괜찮을 것 같음!
<img width="343" alt="스크린샷 2022-03-30 02 20 26" src="https://user-images.githubusercontent.com/82663161/160669266-b59fec35-8bbd-466f-83d0-5d684af13333.png">
