### PR TITLE
이메일 인증 로직 추가 / AlarmService 로직 단순화 및 전역 컨트롤러와의 충돌 해결

### DIFF
--- a/src/main/java/com/community/TestDataInit.java
+++ b/src/main/java/com/community/TestDataInit.java
@@ -59,13 +59,13 @@ public class TestDataInit {
             boardRepository.save(new Board(null, "정보", "java", "스프링 MVC 모델과 스프링 부트에 대한 설명","스프링은 어렵습니다.", null, null, false,4,FORUM_TEST_CONTENT_VALUE1, accountRepository.findByEmail("test@naver.com"), 0, LocalDateTime.now().minusSeconds(40), null));*/
         }
 
-        if (!accountRepository.existsByStudentId("17-100424")) {
+        /*if (!accountRepository.existsByStudentId("17-100424")) {
             accountRepository.save(new Account(null, "dlwlgns1240@nsu.ac.kr", "ezhoon", "17-100424", "이지훈", passwordEncoder.encode("12401240"),
                     true, "asdf1", null, null, LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1),
                     "잘 부탁드립니다", "https://github.com/lee-ji-hoon", "대학생", "서울, 용산", null,null,null, true, true,
                     true, true, true, true, null));
-            /*boardRepository.save(new Board(null, "자유", "", "오늘 학식은 뭔가요?", null, null, null, false, 0,BOARD_CONTENT_VALUE, accountRepository.findByEmail("dlwlgns1240@naver.com"), 0, LocalDateTime.now().minusHours(1), null));*/
-        }
+            *//*boardRepository.save(new Board(null, "자유", "", "오늘 학식은 뭔가요?", null, null, null, false, 0,BOARD_CONTENT_VALUE, accountRepository.findByEmail("dlwlgns1240@naver.com"), 0, LocalDateTime.now().minusHours(1), null));*//*
+        }*/
 
         /*if (!accountRepository.existsByStudentId("17-100425")) {
             accountRepository.save(new Account(null, "tester3@nsu.ac.kr", "tester3", "17-100425", "테스터", passwordEncoder.encode("12401240"),

--- a/src/main/java/com/community/web/controller/AccountController.java
+++ b/src/main/java/com/community/web/controller/AccountController.java
@@ -85,6 +85,7 @@ public class AccountController {
     @GetMapping("/check-email")
     public String checkEmail(@CurrentUser Account account, Model model) {
         model.addAttribute("email", account.getEmail());
+        model.addAttribute(account);
         return "account/check-email";
     }
 
@@ -94,6 +95,7 @@ public class AccountController {
         if (!account.canSendConfirmEmail()) {
             model.addAttribute("error", "인증 이메일은 1시간에 한번만 전송할 수 있습니다.");
             model.addAttribute("email", account.getEmail());
+            model.addAttribute(account);
             return "account/check-email";
         }
 

--- a/src/main/java/com/community/web/controller/BaseController.java
+++ b/src/main/java/com/community/web/controller/BaseController.java
@@ -55,38 +55,43 @@ public class BaseController {
     // @Controller 또는 @ControllerAdvice를 사용한 클래에스 모델 정보를 초기화할 때 사용한다.
     @ModelAttribute()
     public void globalChatNotify(Model model, @CurrentUser Account account) {
-        // 현재 계정이 참여중인 Room을 찾는 로직
-        List<Room> findMyRooms = new ArrayList<>();
-        List<Room> roomHostByAccount = roomRepository.findByRoomHostOrderByLastSendTimeDesc(account);
-        List<Room> roomAttenderByAccount = roomRepository.findByRoomAttenderOrderByLastSendTimeDesc(account);
+        log.info("account : {}", account);
+        if(account != null){
+            // 현재 계정이 참여중인 Room을 찾는 로직
+            List<Room> findMyRooms = new ArrayList<>();
+            List<Room> roomHostByAccount = roomRepository.findByRoomHostOrderByLastSendTimeDesc(account);
+            List<Room> roomAttenderByAccount = roomRepository.findByRoomAttenderOrderByLastSendTimeDesc(account);
 
-        // 해당 Room의 ChatList를 가져오는 로직
-        List<Chat> chatNotifyLists = new ArrayList<>();
-        findMyRooms.addAll(roomAttenderByAccount);
-        findMyRooms.addAll(roomHostByAccount);
+            // 해당 Room의 ChatList를 가져오는 로직
+            List<Chat> chatNotifyLists = new ArrayList<>();
+            findMyRooms.addAll(roomAttenderByAccount);
+            findMyRooms.addAll(roomHostByAccount);
 
-        for (Room findMyRoom : findMyRooms) {
-            List<Chat> readChkFalseChat = chatRepository.findByRoomAndReadChk(findMyRoom, false);
-            for (Chat chat : readChkFalseChat) {
-                if (!account.getNickname().equals(chat.getSender().getNickname())) {
-                    chatNotifyLists.add(chat);
+            for (Room findMyRoom : findMyRooms) {
+                List<Chat> readChkFalseChat = chatRepository.findByRoomAndReadChk(findMyRoom, false);
+                for (Chat chat : readChkFalseChat) {
+                    if (!account.getNickname().equals(chat.getSender().getNickname())) {
+                        chatNotifyLists.add(chat);
+                    }
                 }
             }
+            model.addAttribute("g_chatNotify", chatNotifyLists);
+            model.addAttribute("g_chatService", chatService);
+            model.addAttribute("g_myRoom", findMyRooms);
         }
-        model.addAttribute("g_chatNotify", chatNotifyLists);
-        model.addAttribute("g_chatService", chatService);
-        model.addAttribute("g_myRoom", findMyRooms);
     }
 
     @ModelAttribute()
     public void globalAlarmNotify(Model model, @CurrentUser Account account) {
         // 알림
-        log.info("baseController.java의 alarm 실해 ");
-        List<Alarm> alarmList = alarmRepository.findByToAccountAndCheckedOrderByCreateAlarmTimeDesc(account, false);
-        long countByAccountAndNotChecked = alarmRepository.countByToAccountAndChecked(account, false);
-        log.info("alarm 수 : {}", countByAccountAndNotChecked);
+        if(account != null) {
+            log.info("baseController.java의 alarm 실해 ");
+            List<Alarm> alarmList = alarmRepository.findByToAccountAndCheckedOrderByCreateAlarmTimeDesc(account, false);
+            long countByAccountAndNotChecked = alarmRepository.countByToAccountAndChecked(account, false);
+            log.info("alarm 수 : {}", countByAccountAndNotChecked);
 
-        model.addAttribute("g_accountAlarmNotChecked", alarmList);
-        model.addAttribute("g_countByAccountAndNotChecked", countByAccountAndNotChecked);
+            model.addAttribute("g_accountAlarmNotChecked", alarmList);
+            model.addAttribute("g_countByAccountAndNotChecked", countByAccountAndNotChecked);
+        }
     }
 }

--- a/src/main/java/com/community/web/controller/StudyController.java
+++ b/src/main/java/com/community/web/controller/StudyController.java
@@ -134,17 +134,28 @@ public class StudyController {
 
     // 스터디 추가 뷰
     @GetMapping(STUDY_FORM_URL)
-    public String newStudyForm(@CurrentUser Account account, Model model) {
+    public String newStudyForm(@CurrentUser Account account, Model model, RedirectAttributes redirectAttributes) {
+        boolean emailVerified = account.isEmailVerified();
+
+        log.info("email 체크 : {}", emailVerified);
+        if (!emailVerified) {
+            model.addAttribute(account);
+            redirectAttributes.addFlashAttribute("emailVerifiedChecked", "이메일 인증 후에 사용 가능합니다.");
+
+            return "redirect:/study";
+        }
+
         model.addAttribute(account);
         model.addAttribute(new StudyForm());
         return STUDY_FORM_VIEW;
+
 
     }
 
     // 스터디 추가
     @PostMapping(STUDY_FORM_URL)
-    public String newStudySubmit(@CurrentUser Account account, @Valid StudyForm studyForm, Errors errors, Model model,
-                                 HttpServletRequest httpServletRequest) {
+    public String newStudySubmit(@CurrentUser Account account, @Valid StudyForm studyForm, Errors errors, Model model) {
+
         if (errors.hasErrors()) {
             model.addAttribute(account);
             return STUDY_FORM_VIEW;
@@ -308,7 +319,18 @@ public class StudyController {
 
     // 스터디 참여
     @GetMapping(STUDY_PATH_VIEW + "/join")
-    public String joinStudy(@CurrentUser Account account, @PathVariable String path, RedirectAttributes redirectAttributes) {
+    public String joinStudy(@CurrentUser Account account, @PathVariable String path, Model model,
+                            RedirectAttributes redirectAttributes) {
+        boolean emailVerified = account.isEmailVerified();
+
+        log.info("email 체크 : {}", emailVerified);
+        if (!emailVerified) {
+            model.addAttribute(account);
+            redirectAttributes.addFlashAttribute("emailVerifiedChecked", "이메일 인증 후에 사용 가능합니다.");
+
+            return "redirect:/study/" + fixPath(path);
+        }
+
         Study study = studyRepository.findStudyWithMembersByPath(path);
 
         boolean checkBlockMembers = studyService.checkBlockMembers(study, account);

--- a/src/main/resources/templates/account/check-email.html
+++ b/src/main/resources/templates/account/check-email.html
@@ -3,24 +3,31 @@
 <head th:replace="theme-fragments.html :: head"></head>
 <body class="bg-light">
 <header th:replace="theme-fragments.html :: header"></header>
+<div th:replace="theme-fragments.html :: side_bar"></div>
 
-    <div class="container">
-        <div class="py-5 text-center" th:if="${error != null}">
-            <p class="lead">멀티커뮤니티 가입</p>
-            <div  class="alert alert-danger" role="alert" th:text="${error}"></div>
-            <p class="lead" th:text="${email}">your@email.com</p>
-        </div>
-
-        <div class="py-5 text-center" th:if="${error == null}">
-            <p class="lead">멀티커뮤니티 가입</p>
-
-            <h2>멀티커뮤니티 서비스를 사용하려면 인증 이메일을 확인하세요.</h2>
-
-            <div>
+    <div class="main_content">
+        <div class="mcontainer">
+            <div class="alert alert-warning" role="alert" th:if="${account != null && !account.emailVerified}">
+                unect 가입을 완료하려면 <a href="#" th:href="@{/check-email}" class="alert-link">계정 인증 이메일을 확인</a>하세요.
+            </div>
+            <div class="py-5 text-center" th:if="${error != null}">
+                <p class="lead">unect 가입</p>
+                <div  class="alert alert-danger" role="alert" th:text="${error}"></div>
                 <p class="lead" th:text="${email}">your@email.com</p>
-                <a class="btn btn-outline-info" th:href="@{/resend-confirm-email}">인증 이메일 다시 보내기</a>
+            </div>
+
+            <div class="py-5 text-center" th:if="${error == null}">
+                <p class="lead">unect 가입</p>
+
+                <h2>unect 서비스를 사용하려면 인증 이메일을 확인하세요.</h2>
+
+                <div>
+                    <p class="lead" th:text="${email}">your@email.com</p>
+                    <a class="btn btn-outline-info" th:href="@{/resend-confirm-email}">인증 이메일 다시 보내기</a>
+                </div>
             </div>
         </div>
     </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/account/check-email.html
+++ b/src/main/resources/templates/account/check-email.html
@@ -7,9 +7,6 @@
 
     <div class="main_content">
         <div class="mcontainer">
-            <div class="alert alert-warning" role="alert" th:if="${account != null && !account.emailVerified}">
-                unect 가입을 완료하려면 <a href="#" th:href="@{/check-email}" class="alert-link">계정 인증 이메일을 확인</a>하세요.
-            </div>
             <div class="py-5 text-center" th:if="${error != null}">
                 <p class="lead">unect 가입</p>
                 <div  class="alert alert-danger" role="alert" th:text="${error}"></div>

--- a/src/main/resources/templates/account/checked-email.html
+++ b/src/main/resources/templates/account/checked-email.html
@@ -7,19 +7,19 @@
 
 <div class="container" style="margin-top: 150px">
     <div class="py-5 text-center" th:if="${error}">
-        <p class="text-5xl">멀티커뮤니티 이메일 확인</p>
+        <p class="text-5xl">unect 이메일 확인</p>
         <div class="alert alert-danger" role="alert">
             이메일 확인 링크가 정확하지 않습니다.
         </div>
     </div>
 
     <div class="py-5 text-center" th:if="${error == null}">
-        <p class="text-5xl">멀티커뮤니티 이메일 확인</p>
+        <p class="text-5xl">unect 이메일 확인</p>
         <h2><br>
            이메일을 확인했습니다. <span th:text="${numberOfUser}">N</span>번째 회원,
             <span th:text="${nickname}">이지훈</span>님 가입을 축하합니다.
         </h2>
-        <small class="text-info">이제부터 가입할 때 사용한 이메일 또는 닉네임과 패스트워드로 로그인 할 수 있습니다.</small>
+        <small class="text-info">이제부터 unect 커뮤니티의 모든 기능을 사용 할 수 있습니다.</small>
     </div>
 </div>
 

--- a/src/main/resources/templates/account/email-login-view.html
+++ b/src/main/resources/templates/account/email-login-view.html
@@ -7,14 +7,14 @@
 
     <div class="container" style="margin-top: 150px">
         <div class="py-5 text-center" th:if="${error}">
-            <p class="text-5xl">멀티커뮤니티 이메일 로그인 실패</p>
+            <p class="text-5xl">unect 이메일 로그인 실패</p>
             <div  class="alert alert-danger" role="alert" th:text="${error}">
                 로그인 할 수 없습니다.
             </div>
         </div>
 
         <div class="py-5 text-center" th:if="${error == null}">
-            <p class="text-5xl">멀티커뮤니티 이메일 로그인 성공</p><br>
+            <p class="text-5xl">unect 이메일 로그인 성공</p><br>
             <h2>이메일로 로그인 했습니다. <a th:href="@{/settings/password}"><b style="color: red">패스워드를 변경</b></a>하세요.</h2>
         </div>
     </div>

--- a/src/main/resources/templates/account/email-login.html
+++ b/src/main/resources/templates/account/email-login.html
@@ -44,8 +44,6 @@
             </form>
         </div>
 
-        <div th:replace="fragments.html :: footer"></div>
     </div>
-    <script th:replace="fragments.html :: form-validation"></script>
 </body>
 </html>

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -22,6 +22,7 @@
     <div class="main_content">
         <div class="mcontainer">
             <!-- Profile cover -->
+            <div th:replace="theme-fragments.html :: checked-email"></div>
             <div id="isUpdatedForm">
                 <div id="isUpdated"></div>
             </div>

--- a/src/main/resources/templates/account/send-email-link.html
+++ b/src/main/resources/templates/account/send-email-link.html
@@ -2,11 +2,11 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
-  <title>멀티커뮤니티</title>
+  <title>unect</title>
 </head>
 <body>
 <div>
-  <p>안녕하세요. <span th:text="${username}"></span>님 멀티커뮤니티 입니다. </p><p>아래 내용의 방법을 확인해주세요</p>
+  <p>안녕하세요. <span th:text="${username}"></span>님 unect 입니다. </p><p>아래 내용의 방법을 확인해주세요</p>
 
   <h2 th:text="${message}">상세 내용</h2>
 
@@ -21,7 +21,7 @@
   010-1251-1241
 </div>
 <footer>
-  <p>멀티커뮤니티 2022</p>
+  <p>unect 2022</p>
 </footer>
 </body>
 </html>

--- a/src/main/resources/templates/alarm/view.html
+++ b/src/main/resources/templates/alarm/view.html
@@ -14,6 +14,8 @@
 
     <div class="main_content">
         <div class="mcontainer">
+            <div th:replace="theme-fragments.html :: checked-email"></div>
+
             <div class="bg-white lg:divide-x lg:flex lg:shadow-md rounded-md shadow lg:rounded-xl overflow-hidden lg:m-0 -mx-4 ">
                 <div class="lg:w-1/3">
                     <nav class="responsive-nav setting-nav setting-menu">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -11,12 +11,9 @@
     <header th:replace="theme-fragments.html :: header"></header>
     <div sec:authorize="isAuthenticated()" th:replace="theme-fragments.html :: side_bar(currentSideMenu='index')"></div>
 
-    <div class="alert alert-warning" role="alert" th:if="${account != null && !account.emailVerified}">
-        멀티커뮤니티 가입을 완료하려면 <a href="#" th:href="@{/check-email}" class="alert-link">계정 인증 이메일을 확인</a>하세요.
-    </div>
-
     <div class="main_content">
         <div class="mcontainer">
+            <div th:replace="theme-fragments.html :: checked-email"></div>
             <div class="lg:flex lg:space-x-10">
 
                 <div class="lg:w-2/3">

--- a/src/main/resources/templates/study/study-list.html
+++ b/src/main/resources/templates/study/study-list.html
@@ -15,6 +15,8 @@
     <!-- Main Contents -->
     <div class="main_content">
         <div class="mcontainer">
+            <div th:replace="theme-fragments.html :: checked-email"></div>
+
             <div class="lg:flex lg:space-x-10">
                 <div class="lg:w-3/4">
                     <div class="flex justify-between relative md:mb-4 mb-3">

--- a/src/main/resources/templates/study/study-view.html
+++ b/src/main/resources/templates/study/study-view.html
@@ -19,6 +19,7 @@
 
             <div class="md:flex  md:space-x-8">
                 <div class="space-y-5 flex-shrink-0 md:w-7/12">
+                    <div th:replace="theme-fragments.html :: checked-email"></div>
                     <div th:if="${message}">
                         <div th:replace="theme-fragments.html :: blue-notice(message=${message})"></div>
                     </div>

--- a/src/main/resources/templates/theme-fragments.html
+++ b/src/main/resources/templates/theme-fragments.html
@@ -767,6 +767,15 @@
     </script>
 </div>
 
+<div th:fragment="checked-email">
+    <div class="alert alert-warning" role="alert" th:if="${account != null && !account.emailVerified}">
+        <a href="#" th:href="@{/check-email}" class="alert-link">unect 가입을 완료해주세요. </a>인증 전까지는 몇몇 서비스를 사용 할 수 없습니다.
+    </div>
+    <div class="mb-3" th:if="${emailVerifiedChecked}">
+        <div th:replace="theme-fragments.html :: red-notice(message=${emailVerifiedChecked})"></div>
+    </div>
+</div>
+
 <div th:fragment="profile-settings-menu (currentMenu)" class="lg:w-1/3">
     <nav class="responsive-nav setting-nav setting-menu"
          uk-sticky="top:30 ; offset:80 ; media:@m ;bottom:true; animation: uk-animation-slide-top">


### PR DESCRIPTION
## 추가사항
- [ ] 이메일 인증시에만 특정 서비스 이용 가능하게 변경 `StudyController` 324~332 참고

![image](https://user-images.githubusercontent.com/53300830/161302103-192a0bd0-dacd-464c-9ee1-ebc3ca043172.png)
- [ ] `AlarmController` 로직 단순화 
- [ ] `header-alarm` 와 `BaseController` 충동 해결
- [ ] `application-properties` MySql 데이터베이스 Amazon RDS로 이동
- [ ] view 화면에 이메일 인증 안된 회원은 특정 fragments 추가 `study/study-view`22줄 참고

![image](https://user-images.githubusercontent.com/53300830/161301985-7b084186-8f7a-46b6-8771-52d475b26744.png)


## 버그
배포된 상태에서 profile 다른 사람 것으로 들어갔을 때 프로필 수정 클릭이 되며 정보들이 수정되지 않음

## 필수
`dev`로만 작업
`create-drop`