### PR TITLE
Board 클래스 단의 Setter 제거 및 부분 로직 변경

### DIFF
--- a/src/main/java/com/community/domain/board/Board.java
+++ b/src/main/java/com/community/domain/board/Board.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Setter
+@Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -23,16 +23,20 @@ import java.util.List;
 public class Board extends BaseEntity {
 
     //post_sort
+    @Setter
     private String boardTitle;
 
     //post_sub_sort
+    @Setter
     private String subBoardTitle;
 
-    @NotBlank
     //post_title
+    @NotBlank
+    @Setter
     private String title;
 
     //post_sub_title
+    @Setter
     private String subTitle;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -52,6 +56,7 @@ public class Board extends BaseEntity {
     private Integer reportCount;
 
     @NotBlank
+    @Setter
     @Column(columnDefinition = "TEXT")
     private String content;
 
@@ -60,4 +65,28 @@ public class Board extends BaseEntity {
     private Account writer;
 
     private Integer pageView;
+
+    public void setBasicInfo(Account account) {
+        this.isReported = false;
+        this.pageView = 0;
+        this.reportCount = 0;
+        this.writer = account;
+    }
+
+    public void setReportReset() {
+        this.reportCount = 0;
+        this.isReported = false;
+    }
+
+    public void increasePageView() {
+        this.pageView += 1;
+    }
+
+    public void increaseReportCount() {
+        this.reportCount += 1;
+    }
+
+    public void setReported() {
+        this.isReported = true;
+    }
 }

--- a/src/main/java/com/community/service/ReportService.java
+++ b/src/main/java/com/community/service/ReportService.java
@@ -41,10 +41,9 @@ public class ReportService {
                 .report_content(reportForm.getReport_content())
                 .build();
         boardReportRepository.save(boardReport);
-        Integer boardReportCount = board.getReportCount();
-        board.setReportCount(++boardReportCount);
-        if (boardReportCount >= MAX_BOARD_AND_REPLY_REPORT_COUNT) {
-            board.setIsReported(true);
+        board.increaseReportCount();
+        if (board.getReportCount() >= MAX_BOARD_AND_REPLY_REPORT_COUNT) {
+            board.setReported();
         }
         boardRepository.save(board);
     }


### PR DESCRIPTION
- 클래스 단위의 `@Setter` 제거 후 필드 단위의 `@Setter` 지정
    - `ModelMapper` 사용을 위함
- 조회수 증가 로직 조정
- 서비스단의 수정 로직을 엔티티에 위임